### PR TITLE
Improve type inference by moving variables to last position in hooks

### DIFF
--- a/EXAMPLES/bsconfig.json
+++ b/EXAMPLES/bsconfig.json
@@ -2,11 +2,8 @@
   "name": "examples",
   "graphql": {
     "extend-mutation": "ApolloClient.GraphQL_PPX.ExtendMutation",
-    "extend-mutation-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendMutationNoRequiredVariables",
     "extend-query": "ApolloClient.GraphQL_PPX.ExtendQuery",
-    "extend-query-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendQueryNoRequiredVariables",
-    "extend-subscription": "ApolloClient.GraphQL_PPX.ExtendSubscription",
-    "extend-subscription-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendSubscriptionNoRequiredVariables"
+    "extend-subscription": "ApolloClient.GraphQL_PPX.ExtendSubscription"
   },
   "package-specs": [
     {
@@ -17,7 +14,6 @@
   "ppx-flags": [
     [
       "@reasonml-community/graphql-ppx/ppx",
-      "-fragment-in-query=include",
       "-template-tag-return-type=ApolloClient.GraphQL_PPX.templateTagReturnType",
       "-template-tag-import=gql",
       "-template-tag-location=@apollo/client"

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -11,7 +11,7 @@
     "dedupe": "npm dedupe bs-platform reason-react --no-package-lock"
   },
   "devDependencies": {
-    "@reasonml-community/graphql-ppx": "^1.0.0-beta.17",
+    "@reasonml-community/graphql-ppx": "^1.0.0-beta.18",
     "bs-platform": "^7.3.2",
     "html-webpack-plugin": "^4.3.0",
     "webpack": "^4.43.0",
@@ -24,10 +24,10 @@
     "@jeddeloh/reason-apollo-client": "../",
     "@yawaramin/prometo": "0.11.0",
     "graphql": "^14.0.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "reason-promise": "1.1.1",
-    "reason-react": "^0.9.1",
-    "subscriptions-transport-ws": "^0.9.16"
+    "reason-react": "0.9.1",
+    "subscriptions-transport-ws": "0.9.16"
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,16 +53,12 @@ Add the following to `bs-dependencies`, `graphql`, and `ppx-flags` in your `bsco
   "graphql": {
 +   "apollo-mode": true,
 +   "extend-mutation": "ApolloClient.GraphQL_PPX.ExtendMutation",
-+   "extend-mutation-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendMutationNoRequiredVariables",
 +   "extend-query": "ApolloClient.GraphQL_PPX.ExtendQuery",
-+   "extend-query-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendQueryNoRequiredVariables",
 +   "extend-subscription": "ApolloClient.GraphQL_PPX.ExtendSubscription",
-+   "extend-subscription-no-required-variables": "ApolloClient.GraphQL_PPX.ExtendSubscriptionNoRequiredVariables"
   },
   "ppx-flags": [
     [
       "@reasonml-community/graphql-ppx/ppx",
-+     "-fragment-in-query=include",
 +     "-template-tag-return-type=ApolloClient.GraphQL_PPX.templateTagReturnType",
 +     "-template-tag-import=gql",
 +     "-template-tag-location=@apollo/client"

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
@@ -5,7 +5,6 @@ module Graphql = ApolloClient__Graphql;
 module LazyQueryHookOptions = ApolloClient__React_Types.LazyQueryHookOptions;
 module QueryTuple = ApolloClient__React_Types.QueryTuple;
 module QueryTuple__noVariables = ApolloClient__React_Types.QueryTuple__noVariables;
-module QueryTuple__optionalVariables = ApolloClient__React_Types.QueryTuple__optionalVariables;
 module Types = ApolloClient__Types;
 module Utils = ApolloClient__Utils;
 module WatchQueryFetchPolicy = ApolloClient__Core_WatchQueryOptions.WatchQueryFetchPolicy;
@@ -28,6 +27,8 @@ module Js_ = {
 let useLazyQuery:
   type data jsVariables.
     (
+      ~query: (module Operation with
+                 type t = data and type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -39,11 +40,11 @@ let useLazyQuery:
       ~partialRefetch: bool=?,
       ~pollInterval: int=?,
       ~ssr: bool=?,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      unit
     ) =>
     QueryTuple.t(data, jsVariables) =
   (
+    ~query as (module Operation),
     ~client=?,
     ~context=?,
     ~displayName=?,
@@ -55,7 +56,7 @@ let useLazyQuery:
     ~partialRefetch=?,
     ~pollInterval=?,
     ~ssr=?,
-    (module Operation),
+    (),
   ) => {
     let jsQueryTuple =
       Js_.useLazyQuery(.
@@ -94,6 +95,8 @@ let useLazyQuery:
 let useLazyQueryWithVariables:
   type data jsVariables.
     (
+      ~query: (module Operation with
+                 type t = data and type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -105,12 +108,11 @@ let useLazyQueryWithVariables:
       ~partialRefetch: bool=?,
       ~pollInterval: int=?,
       ~ssr: bool=?,
-      ~variables: jsVariables,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      jsVariables
     ) =>
     QueryTuple__noVariables.t(data, jsVariables) =
   (
+    ~query as (module Operation),
     ~client=?,
     ~context=?,
     ~displayName=?,
@@ -122,8 +124,7 @@ let useLazyQueryWithVariables:
     ~partialRefetch=?,
     ~pollInterval=?,
     ~ssr=?,
-    ~variables,
-    (module Operation),
+    variables,
   ) => {
     let jsQueryTuple =
       Js_.useLazyQuery(.
@@ -155,73 +156,6 @@ let useLazyQueryWithVariables:
           ~serialize=Operation.serialize,
           // Passing in the same variables from above allows us to reuse some types
           ~variables,
-        )
-      },
-      jsQueryTuple,
-    );
-  };
-
-let useLazyQuery0:
-  type data jsVariables.
-    (
-      ~client: ApolloClient.t=?,
-      ~context: Js.Json.t=?,
-      ~displayName: string=?,
-      ~errorPolicy: ErrorPolicy.t=?,
-      ~fetchPolicy: WatchQueryFetchPolicy.t=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~onCompleted: data => unit=?,
-      ~onError: ApolloError.t => unit=?,
-      ~partialRefetch: bool=?,
-      ~pollInterval: int=?,
-      ~ssr: bool=?,
-      (module Types.OperationNoRequiredVars with
-         type t = data and type Raw.t_variables = jsVariables)
-    ) =>
-    QueryTuple__optionalVariables.t(data, jsVariables) =
-  (
-    ~client=?,
-    ~context=?,
-    ~displayName=?,
-    ~errorPolicy=?,
-    ~fetchPolicy=?,
-    ~notifyOnNetworkStatusChange=?,
-    ~onCompleted=?,
-    ~onError=?,
-    ~partialRefetch=?,
-    ~pollInterval=?,
-    ~ssr=?,
-    (module Operation),
-  ) => {
-    let jsQueryTuple =
-      Js_.useLazyQuery(.
-        Operation.query,
-        LazyQueryHookOptions.toJs(
-          {
-            client,
-            context,
-            displayName,
-            errorPolicy,
-            fetchPolicy,
-            onCompleted,
-            onError,
-            notifyOnNetworkStatusChange,
-            partialRefetch,
-            pollInterval,
-            query: None,
-            ssr,
-            variables: None,
-          },
-          ~parse=Operation.parse,
-        ),
-      );
-
-    Utils.useGuaranteedMemo1(
-      () => {
-        jsQueryTuple->QueryTuple__optionalVariables.fromJs(
-          ~defaultVariables=Operation.makeDefaultVariables(),
-          ~parse=Operation.parse,
-          ~serialize=Operation.serialize,
         )
       },
       jsQueryTuple,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
@@ -6,7 +6,6 @@ module Graphql = ApolloClient__Graphql;
 module MutationHookOptions = ApolloClient__React_Types.MutationHookOptions;
 module MutationTuple = ApolloClient__React_Types.MutationTuple;
 module MutationTuple__noVariables = ApolloClient__React_Types.MutationTuple__noVariables;
-module MutationTuple__optionalVariables = ApolloClient__React_Types.MutationTuple__optionalVariables;
 module MutationUpdaterFn = ApolloClient__Core_WatchQueryOptions.MutationUpdaterFn;
 module OperationVariables = ApolloClient__Core_Types.OperationVariables;
 module RefetchQueryDescription = ApolloClient__Core_WatchQueryOptions.RefetchQueryDescription;
@@ -31,6 +30,8 @@ module Js_ = {
 let useMutation:
   type data jsVariables.
     (
+      ~mutation: (module Operation with
+                    type t = data and type Raw.t_variables = jsVariables),
       ~awaitRefetchQueries: bool=?,
       ~context: Js.Json.t=?,
       ~client: ApolloClient.t=?,
@@ -43,11 +44,11 @@ let useMutation:
       ~optimisticResponse: jsVariables => data=?,
       ~refetchQueries: RefetchQueryDescription.t=?,
       ~update: MutationUpdaterFn.t(data)=?,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      unit
     ) =>
     MutationTuple.t(data, jsVariables) =
   (
+    ~mutation as (module Operation),
     ~awaitRefetchQueries=?,
     ~context=?,
     ~client=?,
@@ -60,7 +61,7 @@ let useMutation:
     ~optimisticResponse=?,
     ~refetchQueries=?,
     ~update=?,
-    (module Operation),
+    (),
   ) => {
     let jsMutationTuple =
       Js_.useMutation(.
@@ -101,6 +102,8 @@ let useMutation:
 let useMutationWithVariables:
   type data jsVariables.
     (
+      ~mutation: (module Operation with
+                    type t = data and type Raw.t_variables = jsVariables),
       ~awaitRefetchQueries: bool=?,
       ~context: Js.Json.t=?,
       ~client: ApolloClient.t=?,
@@ -113,12 +116,11 @@ let useMutationWithVariables:
       ~optimisticResponse: jsVariables => data=?,
       ~refetchQueries: RefetchQueryDescription.t=?,
       ~update: MutationUpdaterFn.t(data)=?,
-      ~variables: jsVariables,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      jsVariables
     ) =>
     MutationTuple__noVariables.t(data, jsVariables) =
   (
+    ~mutation as (module Operation),
     ~awaitRefetchQueries=?,
     ~context=?,
     ~client=?,
@@ -131,8 +133,7 @@ let useMutationWithVariables:
     ~optimisticResponse=?,
     ~refetchQueries=?,
     ~update=?,
-    ~variables,
-    (module Operation),
+    variables,
   ) => {
     let jsMutationTuple =
       Js_.useMutation(.
@@ -174,77 +175,6 @@ let useMutationWithVariables:
     );
   };
 
-let useMutation0:
-  type data jsVariables.
-    (
-      ~awaitRefetchQueries: bool=?,
-      ~context: Js.Json.t=?,
-      ~client: ApolloClient.t=?,
-      ~errorPolicy: ErrorPolicy.t=?,
-      ~fetchPolicy: FetchPolicy__noCacheExtracted.t=?,
-      ~ignoreResults: bool=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~onError: ApolloError.t => unit=?,
-      ~onCompleted: data => unit=?,
-      ~optimisticResponse: jsVariables => data=?,
-      ~refetchQueries: RefetchQueryDescription.t=?,
-      ~update: MutationUpdaterFn.t(data)=?,
-      (module OperationNoRequiredVars with
-         type t = data and type Raw.t_variables = jsVariables)
-    ) =>
-    MutationTuple__optionalVariables.t(data, jsVariables) =
-  (
-    ~awaitRefetchQueries=?,
-    ~context=?,
-    ~client=?,
-    ~errorPolicy=?,
-    ~fetchPolicy=?,
-    ~ignoreResults=?,
-    ~notifyOnNetworkStatusChange=?,
-    ~onError=?,
-    ~onCompleted=?,
-    ~optimisticResponse=?,
-    ~refetchQueries=?,
-    ~update=?,
-    (module OperationNoRequiredVars),
-  ) => {
-    let jsMutationTuple =
-      Js_.useMutation(.
-        OperationNoRequiredVars.query,
-        MutationHookOptions.toJs(
-          {
-            mutation: None,
-            awaitRefetchQueries,
-            context,
-            client,
-            errorPolicy,
-            fetchPolicy,
-            ignoreResults,
-            notifyOnNetworkStatusChange,
-            onError,
-            onCompleted,
-            optimisticResponse,
-            refetchQueries,
-            update,
-            variables: Some(OperationNoRequiredVars.makeDefaultVariables()),
-          },
-          ~parse=OperationNoRequiredVars.parse,
-          ~serialize=OperationNoRequiredVars.serialize,
-        ),
-      );
-
-    Utils.useGuaranteedMemo1(
-      () => {
-        jsMutationTuple->MutationTuple__optionalVariables.fromJs(
-          ~defaultVariables=OperationNoRequiredVars.makeDefaultVariables(),
-          ~parse=OperationNoRequiredVars.parse,
-          ~serialize=OperationNoRequiredVars.serialize,
-        )
-      },
-      jsMutationTuple,
-    );
-  };
-
 module Extend = (M: Types.Operation) => {
   let use =
       (
@@ -263,6 +193,7 @@ module Extend = (M: Types.Operation) => {
         (),
       ) => {
     useMutation(
+      ~mutation=(module M),
       ~awaitRefetchQueries?,
       ~context?,
       ~client?,
@@ -275,7 +206,7 @@ module Extend = (M: Types.Operation) => {
       ~optimisticResponse?,
       ~refetchQueries?,
       ~update?,
-      (module M),
+      (),
     );
   };
 
@@ -296,6 +227,7 @@ module Extend = (M: Types.Operation) => {
         variables,
       ) => {
     useMutationWithVariables(
+      ~mutation=(module M),
       ~awaitRefetchQueries?,
       ~context?,
       ~client?,
@@ -308,77 +240,7 @@ module Extend = (M: Types.Operation) => {
       ~optimisticResponse?,
       ~refetchQueries?,
       ~update?,
-      ~variables,
-      (module M),
-    );
-  };
-};
-
-module ExtendNoRequiredVariables = (M: Types.OperationNoRequiredVars) => {
-  let use =
-      (
-        ~awaitRefetchQueries=?,
-        ~context=?,
-        ~client=?,
-        ~errorPolicy=?,
-        ~fetchPolicy=?,
-        ~ignoreResults=?,
-        ~notifyOnNetworkStatusChange=?,
-        ~onError=?,
-        ~onCompleted=?,
-        ~optimisticResponse=?,
-        ~refetchQueries=?,
-        ~update=?,
-        (),
-      ) => {
-    useMutation0(
-      ~awaitRefetchQueries?,
-      ~context?,
-      ~client?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~ignoreResults?,
-      ~notifyOnNetworkStatusChange?,
-      ~onError?,
-      ~onCompleted?,
-      ~optimisticResponse?,
-      ~refetchQueries?,
-      ~update?,
-      (module M),
-    );
-  };
-
-  let useWithVariables =
-      (
-        ~awaitRefetchQueries=?,
-        ~context=?,
-        ~client=?,
-        ~errorPolicy=?,
-        ~fetchPolicy=?,
-        ~ignoreResults=?,
-        ~notifyOnNetworkStatusChange=?,
-        ~onError=?,
-        ~onCompleted=?,
-        ~optimisticResponse=?,
-        ~refetchQueries=?,
-        ~update=?,
-        variables,
-      ) => {
-    useMutationWithVariables(
-      ~awaitRefetchQueries?,
-      ~context?,
-      ~client?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~ignoreResults?,
-      ~notifyOnNetworkStatusChange?,
-      ~onError?,
-      ~onCompleted?,
-      ~optimisticResponse?,
-      ~refetchQueries?,
-      ~update?,
-      ~variables,
-      (module M),
+      variables,
     );
   };
 };

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -24,6 +24,8 @@ module Js_ = {
 let useQuery:
   type data jsVariables.
     (
+      ~query: (module Operation with
+                 type t = data and type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -36,12 +38,11 @@ let useQuery:
       ~pollInterval: int=?,
       ~skip: bool=?,
       ~ssr: bool=?,
-      ~variables: jsVariables,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      jsVariables
     ) =>
     QueryResult.t(data, jsVariables) =
   (
+    ~query as (module Operation),
     ~client=?,
     ~context=?,
     ~displayName=?,
@@ -54,8 +55,7 @@ let useQuery:
     ~pollInterval=?,
     ~skip=?,
     ~ssr=?,
-    ~variables,
-    (module Operation),
+    variables,
   ) => {
     let jsQueryResult =
       Js_.useQuery(.
@@ -92,58 +92,6 @@ let useQuery:
     );
   };
 
-let useQuery0:
-  type data jsVariables.
-    (
-      ~client: ApolloClient.t=?,
-      ~context: Js.Json.t=?,
-      ~displayName: string=?,
-      ~errorPolicy: ErrorPolicy.t=?,
-      ~fetchPolicy: WatchQueryFetchPolicy.t=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~onCompleted: data => unit=?,
-      ~onError: ApolloError.t => unit=?,
-      ~partialRefetch: bool=?,
-      ~pollInterval: int=?,
-      ~skip: bool=?,
-      ~ssr: bool=?,
-      (module Types.OperationNoRequiredVars with
-         type t = data and type Raw.t_variables = jsVariables)
-    ) =>
-    QueryResult.t(data, jsVariables) =
-  (
-    ~client=?,
-    ~context=?,
-    ~displayName=?,
-    ~errorPolicy=?,
-    ~fetchPolicy=?,
-    ~notifyOnNetworkStatusChange=?,
-    ~onCompleted=?,
-    ~onError=?,
-    ~partialRefetch=?,
-    ~pollInterval=?,
-    ~skip=?,
-    ~ssr=?,
-    (module Operation),
-  ) => {
-    useQuery(
-      ~client?,
-      ~context?,
-      ~displayName?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~notifyOnNetworkStatusChange?,
-      ~onCompleted?,
-      ~onError?,
-      ~partialRefetch?,
-      ~pollInterval?,
-      ~skip?,
-      ~ssr?,
-      ~variables=Operation.makeDefaultVariables(),
-      (module Operation),
-    );
-  };
-
 module Extend = (M: Operation) => {
   let refetchQueryDescription:
     (~context: Js.Json.t=?, M.Raw.t_variables) =>
@@ -172,6 +120,7 @@ module Extend = (M: Operation) => {
         variables,
       ) => {
     useQuery(
+      ~query=(module M),
       ~client?,
       ~context?,
       ~displayName?,
@@ -184,8 +133,7 @@ module Extend = (M: Operation) => {
       ~pollInterval?,
       ~skip?,
       ~ssr?,
-      ~variables,
-      (module M),
+      variables,
     );
   };
 
@@ -205,6 +153,7 @@ module Extend = (M: Operation) => {
         (),
       ) => {
     ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery(
+      ~query=(module M),
       ~client?,
       ~context?,
       ~displayName?,
@@ -216,7 +165,7 @@ module Extend = (M: Operation) => {
       ~partialRefetch?,
       ~pollInterval?,
       ~ssr?,
-      (module M),
+      (),
     );
   };
 
@@ -236,6 +185,7 @@ module Extend = (M: Operation) => {
         variables,
       ) => {
     ApolloClient__React_Hooks_UseLazyQuery.useLazyQueryWithVariables(
+      ~query=(module M),
       ~client?,
       ~context?,
       ~displayName?,
@@ -247,122 +197,7 @@ module Extend = (M: Operation) => {
       ~partialRefetch?,
       ~pollInterval?,
       ~ssr?,
-      ~variables,
-      (module M),
-    );
-  };
-};
-
-module ExtendNoRequiredVariables = (M: OperationNoRequiredVars) => {
-  let refetchQueryDescription:
-    (~context: Js.Json.t=?, ~variables: M.Raw.t_variables=?, unit) =>
-    RefetchQueryDescription.t_variant =
-    (~context=?, ~variables: option(M.Raw.t_variables)=?, ()) =>
-      RefetchQueryDescription.PureQueryOptions({
-        query: M.query,
-        variables:
-          variables->Belt.Option.getWithDefault(M.makeDefaultVariables()),
-        context,
-      });
-
-  let use =
-      (
-        ~client=?,
-        ~context=?,
-        ~displayName=?,
-        ~errorPolicy=?,
-        ~fetchPolicy=?,
-        ~notifyOnNetworkStatusChange=?,
-        ~onCompleted=?,
-        ~onError=?,
-        ~partialRefetch=?,
-        ~pollInterval=?,
-        ~skip=?,
-        ~ssr=?,
-        ~variables=?,
-        (),
-      ) => {
-    useQuery(
-      ~client?,
-      ~context?,
-      ~displayName?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~notifyOnNetworkStatusChange?,
-      ~onCompleted?,
-      ~onError?,
-      ~partialRefetch?,
-      ~pollInterval?,
-      ~skip?,
-      ~ssr?,
-      ~variables=
-        variables->Belt.Option.getWithDefault(M.makeDefaultVariables()),
-      (module M),
-    );
-  };
-
-  let useLazy =
-      (
-        ~client=?,
-        ~context=?,
-        ~displayName=?,
-        ~errorPolicy=?,
-        ~fetchPolicy=?,
-        ~notifyOnNetworkStatusChange=?,
-        ~onCompleted=?,
-        ~onError=?,
-        ~partialRefetch=?,
-        ~pollInterval=?,
-        ~ssr=?,
-        (),
-      ) => {
-    ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery0(
-      ~client?,
-      ~context?,
-      ~displayName?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~notifyOnNetworkStatusChange?,
-      ~onCompleted?,
-      ~onError?,
-      ~partialRefetch?,
-      ~pollInterval?,
-      ~ssr?,
-      (module M),
-    );
-  };
-
-  let useLazyWithVariables =
-      (
-        ~client=?,
-        ~context=?,
-        ~displayName=?,
-        ~errorPolicy=?,
-        ~fetchPolicy=?,
-        ~notifyOnNetworkStatusChange=?,
-        ~onCompleted=?,
-        ~onError=?,
-        ~partialRefetch=?,
-        ~pollInterval=?,
-        ~ssr=?,
-        ~variables=?,
-        (),
-      ) => {
-    ApolloClient__React_Hooks_UseLazyQuery.useLazyQueryWithVariables(
-      ~client?,
-      ~context?,
-      ~displayName?,
-      ~errorPolicy?,
-      ~fetchPolicy?,
-      ~notifyOnNetworkStatusChange?,
-      ~onCompleted?,
-      ~onError?,
-      ~partialRefetch?,
-      ~pollInterval?,
-      ~ssr?,
-      ~variables=
-        variables->Belt.Option.getWithDefault(M.makeDefaultVariables()),
-      (module M),
+      variables,
     );
   };
 };

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
@@ -45,6 +45,8 @@ type useSubscription_result('data, 'variables) = {
 let useSubscription:
   type data jsVariables.
     (
+      ~subscription: (module Operation with
+                        type t = data and type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~fetchPolicy: FetchPolicy.t=?,
       ~onSubscriptionData: OnSubscriptionDataOptions.t(data) => unit=?,
@@ -52,20 +54,18 @@ let useSubscription:
       ~shouldResubscribe: BaseSubscriptionOptions.t(data, jsVariables) => bool
                             =?,
       ~skip: bool=?,
-      ~variables: jsVariables,
-      (module Operation with
-         type t = data and type Raw.t_variables = jsVariables)
+      jsVariables
     ) =>
     useSubscription_result(data, jsVariables) =
   (
+    ~subscription as (module Operation),
     ~client=?,
     ~fetchPolicy=?,
     ~onSubscriptionData=?,
     ~onSubscriptionComplete=?,
     ~shouldResubscribe=?,
     ~skip=?,
-    ~variables,
-    (module Operation),
+    variables,
   ) => {
     let jsSubscriptionResult =
       Js_.useSubscription(.
@@ -97,41 +97,6 @@ let useSubscription:
     );
   };
 
-let useSubscription0:
-  type data jsVariables.
-    (
-      ~client: ApolloClient.t=?,
-      ~fetchPolicy: FetchPolicy.t=?,
-      ~onSubscriptionData: OnSubscriptionDataOptions.t(data) => unit=?,
-      ~onSubscriptionComplete: unit => unit=?,
-      ~shouldResubscribe: BaseSubscriptionOptions.t(data, jsVariables) => bool
-                            =?,
-      ~skip: bool=?,
-      (module Types.OperationNoRequiredVars with
-         type t = data and type Raw.t_variables = jsVariables)
-    ) =>
-    useSubscription_result(data, jsVariables) =
-  (
-    ~client=?,
-    ~fetchPolicy=?,
-    ~onSubscriptionData=?,
-    ~onSubscriptionComplete=?,
-    ~shouldResubscribe=?,
-    ~skip=?,
-    (module Operation),
-  ) => {
-    useSubscription(
-      ~client?,
-      ~fetchPolicy?,
-      ~onSubscriptionData?,
-      ~onSubscriptionComplete?,
-      ~shouldResubscribe?,
-      ~skip?,
-      ~variables=Operation.makeDefaultVariables(),
-      (module Operation),
-    );
-  };
-
 module Extend = (M: Operation) => {
   let use =
       (
@@ -141,44 +106,17 @@ module Extend = (M: Operation) => {
         ~onSubscriptionComplete=?,
         ~shouldResubscribe=?,
         ~skip=?,
-        ~variables,
-        (),
+        variables,
       ) => {
     useSubscription(
+      ~subscription=(module M),
       ~client?,
       ~fetchPolicy?,
       ~onSubscriptionData?,
       ~onSubscriptionComplete?,
       ~shouldResubscribe?,
       ~skip?,
-      ~variables,
-      (module M),
-    );
-  };
-};
-
-module ExtendNoRequiredVariables = (M: OperationNoRequiredVars) => {
-  let use =
-      (
-        ~client=?,
-        ~fetchPolicy=?,
-        ~onSubscriptionData=?,
-        ~onSubscriptionComplete=?,
-        ~shouldResubscribe=?,
-        ~skip=?,
-        ~variables=?,
-        (),
-      ) => {
-    useSubscription(
-      ~client?,
-      ~fetchPolicy?,
-      ~onSubscriptionData?,
-      ~onSubscriptionComplete?,
-      ~shouldResubscribe?,
-      ~skip?,
-      ~variables=
-        variables->Belt.Option.getWithDefault(M.makeDefaultVariables()),
-      (module M),
+      variables,
     );
   };
 };

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -407,39 +407,6 @@ module QueryTuple = {
     );
 };
 
-module QueryTuple__optionalVariables = {
-  module Js_ = {
-    type t('jsData, 'variables) = QueryTuple.Js_.t('jsData, 'variables);
-  };
-
-  type t('data, 'variables) = (
-    (~context: Js.Json.t=?, ~variables: 'variables=?, unit) => unit,
-    LazyQueryResult.t('data, 'variables),
-  );
-
-  let fromJs:
-    (
-      Js_.t('jsData, 'variables),
-      ~defaultVariables: 'variables,
-      ~parse: 'jsData => 'data,
-      ~serialize: 'data => 'jsData
-    ) =>
-    t('data, 'variables) =
-    (
-      (jsExecuteQuery, jsLazyQueryResult),
-      ~defaultVariables,
-      ~parse,
-      ~serialize,
-    ) => (
-      (~context=?, ~variables=?, ()) =>
-        jsExecuteQuery({
-          context,
-          variables: variables->Belt.Option.getWithDefault(defaultVariables),
-        }),
-      jsLazyQueryResult->LazyQueryResult.fromJs(~parse, ~serialize),
-    );
-};
-
 module QueryTuple__noVariables = {
   module Js_ = {
     type t('jsData, 'variables) = QueryTuple.Js_.t('jsData, 'variables);
@@ -807,77 +774,6 @@ module MutationTuple__noVariables = {
     ((jsMutationFn, jsMutationResult), ~parse, ~serialize, ~variables) => {
       let mutationFn =
           (
-            ~optimisticResponse=?,
-            ~refetchQueries=?,
-            ~awaitRefetchQueries=?,
-            ~update=?,
-            ~context=?,
-            ~fetchPolicy=?,
-            (),
-          ) => {
-        jsMutationFn(
-          Some(
-            MutationFunctionOptions.toJs(
-              {
-                variables,
-                optimisticResponse,
-                refetchQueries,
-                awaitRefetchQueries,
-                update,
-                context,
-                fetchPolicy,
-              },
-              ~parse,
-              ~serialize,
-            ),
-          ),
-        )
-        ->Js.Promise.then_(
-            jsResult =>
-              FetchResult.fromJs(jsResult, ~parse)->Js.Promise.resolve,
-            _,
-          );
-      };
-
-      (mutationFn, jsMutationResult->MutationResult.fromJs(~parse));
-    };
-};
-
-module MutationTuple__optionalVariables = {
-  module Js_ = {
-    type t('jsData, 'variables) = MutationTuple.Js_.t('jsData, 'variables);
-  };
-
-  type t_mutationFn('data, 'variables) =
-    (
-      ~variables: 'variables=?,
-      ~optimisticResponse: 'variables => 'data=?,
-      ~refetchQueries: RefetchQueryDescription.t=?,
-      ~awaitRefetchQueries: bool=?,
-      ~update: MutationUpdaterFn.t('data)=?,
-      ~context: Js.Json.t=?,
-      ~fetchPolicy: WatchQueryFetchPolicy.t=?,
-      unit
-    ) =>
-    Js.Promise.t(FetchResult.t('data));
-
-  type t('data, 'variables) = (
-    t_mutationFn('data, 'variables),
-    MutationResult.t('data),
-  );
-
-  let fromJs:
-    (
-      Js_.t('jsData, 'variables),
-      ~defaultVariables: 'variables,
-      ~parse: 'jsData => 'data,
-      ~serialize: 'data => 'jsData
-    ) =>
-    t('data, 'variables) =
-    ((jsMutationFn, jsMutationResult), ~defaultVariables, ~parse, ~serialize) => {
-      let mutationFn =
-          (
-            ~variables=defaultVariables,
             ~optimisticResponse=?,
             ~refetchQueries=?,
             ~awaitRefetchQueries=?,

--- a/src/Jeddeloh__ApolloClient.re
+++ b/src/Jeddeloh__ApolloClient.re
@@ -10,11 +10,8 @@ module Bindings = {
 
 module GraphQL_PPX = {
   module ExtendMutation = ApolloClient__React_Hooks_UseMutation.Extend;
-  module ExtendMutationNoRequiredVariables = ApolloClient__React_Hooks_UseMutation.Extend;
   module ExtendQuery = ApolloClient__React_Hooks_UseQuery.Extend;
-  module ExtendQueryNoRequiredVariables = ApolloClient__React_Hooks_UseQuery.Extend;
   module ExtendSubscription = ApolloClient__React_Hooks_UseSubscription.Extend;
-  module ExtendSubscriptionNoRequiredVariables = ApolloClient__React_Hooks_UseSubscription.Extend;
   type templateTagReturnType = ApolloClient__Graphql.documentNode;
 };
 

--- a/src/Jeddeloh__ApolloClient.re
+++ b/src/Jeddeloh__ApolloClient.re
@@ -10,11 +10,11 @@ module Bindings = {
 
 module GraphQL_PPX = {
   module ExtendMutation = ApolloClient__React_Hooks_UseMutation.Extend;
-  module ExtendMutationNoRequiredVariables = ApolloClient__React_Hooks_UseMutation.ExtendNoRequiredVariables;
+  module ExtendMutationNoRequiredVariables = ApolloClient__React_Hooks_UseMutation.Extend;
   module ExtendQuery = ApolloClient__React_Hooks_UseQuery.Extend;
-  module ExtendQueryNoRequiredVariables = ApolloClient__React_Hooks_UseQuery.ExtendNoRequiredVariables;
+  module ExtendQueryNoRequiredVariables = ApolloClient__React_Hooks_UseQuery.Extend;
   module ExtendSubscription = ApolloClient__React_Hooks_UseSubscription.Extend;
-  module ExtendSubscriptionNoRequiredVariables = ApolloClient__React_Hooks_UseSubscription.ExtendNoRequiredVariables;
+  module ExtendSubscriptionNoRequiredVariables = ApolloClient__React_Hooks_UseSubscription.Extend;
   type templateTagReturnType = ApolloClient__Graphql.documentNode;
 };
 
@@ -22,13 +22,11 @@ module React = {
   module ApolloProvider = ApolloClient__React_Context_ApolloProvider;
   let useApolloClient = ApolloClient__React_Hooks_UseApolloClient.useApolloClient;
   let useMutation = ApolloClient__React_Hooks_UseMutation.useMutation;
-  let useMutation0 = ApolloClient__React_Hooks_UseMutation.useMutation0;
+  let useMutationWithVariables = ApolloClient__React_Hooks_UseMutation.useMutationWithVariables;
   let useLazyQuery = ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery;
-  let useLazyQuery0 = ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery0;
+  let useLazyQueryWithVariables = ApolloClient__React_Hooks_UseLazyQuery.useLazyQueryWithVariables;
   let useQuery = ApolloClient__React_Hooks_UseQuery.useQuery;
-  let useQuery0 = ApolloClient__React_Hooks_UseQuery.useQuery0;
   let useSubscription = ApolloClient__React_Hooks_UseSubscription.useSubscription;
-  let useSubscription0 = ApolloClient__React_Hooks_UseSubscription.useSubscription0;
 };
 
 module Utilities = ApolloClient__Utilities;


### PR DESCRIPTION
Here are some proposed changes to the general shape of hooks. They follow the same pattern as client methods where variables are in the last position and required in order to improve type inference. This simplified things quite a bit.

The case where you have some variables but none are _required_ is still slightly awkward, but I think this is a better approach than having the variables arg be optional in that case. If you have optional variables and you're not supplying _any_ seems rare and I would rather someone have to be explicit that they are not passing anything rather than possibly forgetting. 
